### PR TITLE
Historical Statistics Backend Update Code

### DIFF
--- a/actions/stats.ts
+++ b/actions/stats.ts
@@ -1,0 +1,244 @@
+// Buffett May. 26
+import { createClient } from '@supabase/supabase-js'
+import { Database } from '@/database.types'
+
+const db = createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+)
+
+type DailyStats = {
+    date: string
+    amount: number
+    quantity: number
+}
+
+type OrderWithItems = {
+    created_at: string | null
+    total_paid: number | null
+    order_items: {
+        quantity: number | null
+  }[]
+}
+
+type Output = {
+    success: boolean
+    data?: {
+        timeSeries: DailyStats[]
+    }
+    error?: string
+}
+
+type ProductStatsPoint = {
+  date: string
+  amount: number
+  quantity: number
+}
+
+type ProductStats = {
+  product_id: number
+  data: ProductStatsPoint[]
+}
+
+// 賣場整體表現
+// 根據選取的時間範圍，回傳所有商品加總 orders.total_paid （銷售額）、加總 order_items.quantity （銷售量）的時間序列
+// Input: 起始日期, 結束日期
+// Output: 每日銷售額, 每日銷售數量
+// {
+//   "success": true,
+//   "data": [
+//     {
+//       "date": "2024-01-02",
+//       "amount": 3800,
+//       "quantity": 21
+//     },
+//     ...
+//   ]
+// }
+// SQL:
+// SELECT 
+//   orders.created_at,
+//   orders.total_paid,
+//   order_items.quantity
+// FROM orders
+// LEFT JOIN order_items ON orders.order_id = order_items.order_id 
+// WHERE orders.created_at >= '2025-01-01'
+// AND orders.created_at <= '2025-06-01';
+export async function getProductSalesStats(
+  startDate: string, 
+  endDate: string
+): Promise<Output> {
+  console.log("getProductSalesStats", startDate, endDate)
+  try {
+    const { data: stats, error } = await db
+      .from('orders')
+      .select(`
+        created_at,
+        total_paid,
+        order_items (
+          quantity
+        )
+      `)
+      .gte('created_at', startDate)
+      .lte('created_at', endDate)
+
+    if (error) throw error
+
+    const dailyStatsMap = (stats || []).reduce((acc: Record<string, DailyStats>, order: OrderWithItems) => {
+      if (!order.created_at) return acc
+      
+      const date = new Date(order.created_at).toISOString().split('T')[0]
+      if (!acc[date]) {
+        acc[date] = {
+          date,
+          amount: 0,
+          quantity: 0
+        }
+      }
+      acc[date].amount += Number(order.total_paid) || 0
+      acc[date].quantity += (order.order_items || []).reduce((sum: number, item) => sum + (Number(item.quantity) || 0), 0)
+      return acc
+    }, {})
+
+    // Create date list between startDate and endDate
+    const dateList: string[] = []
+    const current = new Date(startDate)
+    const end = new Date(endDate)
+
+    while (current <= end) {
+      const dateStr = current.toISOString().split('T')[0]
+      dateList.push(dateStr)
+      current.setDate(current.getDate() + 1)
+    }
+
+    // Missing Data Date --> {date: "2025-01-01", amount: 0, quantity: 0}
+    const completeStats: DailyStats[] = dateList.map(date => {
+      return dailyStatsMap[date] ?? {
+        date,
+        amount: 0,
+        quantity: 0
+      }
+    })
+
+    return {
+      success: true,
+      data: {
+        timeSeries: completeStats.sort((a, b) => a.date.localeCompare(b.date)),
+      }
+    }
+
+  } catch (error) {
+    console.error('Error getting product sales stats:', error)
+    return {
+      success: false,
+      error: (error as Error).message
+    }
+  }
+}
+
+
+// 當使用者選取商品後，根據選取的時間範圍，回傳所選商品加總 order_items.amount（銷售額）、加總 order_items.quantity （銷售量）的時間序列
+// Input: Product_ID(s), 起始日期, 結束日期
+// Output: Product_IDs: {每日銷售額, 每日銷售數量}
+// {
+//   "success": true,
+//   "data": [
+//     {
+//       "product_id": 1,
+//       "data": [
+//         {
+//            "date": "2024-01-02",
+//            "amount": 3800,
+//            "quantity": 21
+//         },
+//         ...
+//       ]
+//     },
+//   ]
+// }
+export async function getProductStatsByIds(
+  productIds: number[],
+  startDate: string,
+  endDate: string
+): Promise<{ success: boolean; data?: ProductStats[]; error?: string }> {
+  try {
+    // Input validation
+    if (!productIds?.length) {
+      throw new Error('Product IDs are required')
+    }
+
+    const { data: orders, error } = await db
+      .from('orders')
+      .select(`
+        created_at,
+        order_items (
+          product_id,
+          quantity,
+          total_price
+        )
+      `)
+      .gte('created_at', startDate)
+      .lte('created_at', endDate)
+
+    if (error) throw error
+
+    // 建立日期清單
+    const dateList: string[] = []
+    const current = new Date(startDate)
+    const end = new Date(endDate)
+    while (current <= end) {
+      dateList.push(current.toISOString().split('T')[0])
+      current.setDate(current.getDate() + 1)
+    }
+
+    // 初始化 product map: product_id -> { date -> { amount, quantity } }
+    const productMap: Record<number, Record<string, ProductStatsPoint>> = {}
+
+    // Initialize data structure for each product ID and date
+    productIds.forEach(productId => {
+      productMap[productId] = {}
+      dateList.forEach(date => {
+        productMap[productId][date] = {
+          date,
+          amount: 0,
+          quantity: 0
+        }
+      })
+    })
+
+    // Process orders and aggregate data
+    if (orders) {
+      orders.forEach(order => {
+        if (!order.created_at || !order.order_items) return
+        
+        const date = new Date(order.created_at).toISOString().split('T')[0]
+        
+        order.order_items.forEach(item => {
+          if (!item.product_id || !productIds.includes(item.product_id)) return
+          
+          const productStats = productMap[item.product_id][date]
+          if (productStats) {
+            productStats.amount += Number(item.total_price) || 0
+            productStats.quantity += Number(item.quantity) || 0
+          }
+        })
+      })
+    }
+
+    // Convert to final format and sort data
+    const result: ProductStats[] = productIds.map(productId => ({
+      product_id: productId,
+      data: Object.values(productMap[productId]).sort((a, b) => 
+        a.date.localeCompare(b.date)
+      )
+    }))
+
+    return { success: true, data: result }
+  } catch (error) {
+    console.error('Error in getProductStatsByIds:', error)
+    return {
+      success: false,
+      error: (error as Error).message,
+    }
+  }
+}


### PR DESCRIPTION
## Add Sales Stats APIs for Overall and Product-level Analytics

This PR adds two API functions for retrieving sales statistics:

1. **`getProductSalesStats`**
   - Returns daily total sales amount and quantity across all products.
   - Fills in missing dates with zero values.

2. **`getProductStatsByIds`**
   - Accepts an array of `product_ids`.
   - Returns daily sales data (amount and quantity) per product, structured for frontend visualization.
   - Fills in all date ranges between `startDate` and `endDate` even when no sales occurred.

---

### Main Revision

- Used Supabase JS client to query `orders` and related `order_items`.
- Used `.reduce()` and date iteration to aggregate and normalize data by date.
- Ensured consistent format output:

  ```ts
  {
    date: "YYYY-MM-DD",
    amount: number,
    quantity: number
  }

---

### Pictures

- The first image is to show that we can obtain the information of whole Product Sales.
- The second image is to show that we split the data with `productID`.
  
<img width="1337" alt="截圖 2025-05-26 19 34 13" src="https://github.com/user-attachments/assets/76a5ffcd-276d-4629-81d9-9f09bfce605c" />
<img width="1337" alt="截圖 2025-05-26 19 34 41" src="https://github.com/user-attachments/assets/fe454d23-0010-4a0a-8644-515e28650b4d" />