### PR TITLE
Feature/delete product model

### DIFF
--- a/actions/delete.ts
+++ b/actions/delete.ts
@@ -1,0 +1,54 @@
+import { createClient } from '@supabase/supabase-js'
+import { Database } from '@/database.types'
+
+const db = createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+)
+
+type Output = {
+    success: boolean
+    error?: string
+}
+
+
+// Delete product models and related data
+export async function deleteProductModels(modelIds: number[]): Promise<Output> {
+    try {
+      // Delete purchase_items
+      let { error } = await db
+        .from('purchase_items')
+        .delete()
+        .in('model_id', modelIds)
+      if (error) throw error
+  
+      // Delete order_items
+      ;({ error } = await db
+        .from('order_items')
+        .delete()
+        .in('model_id', modelIds))
+      if (error) throw error
+  
+      // Delete stock_records
+      ;({ error } = await db
+        .from('stock_records')
+        .delete()
+        .in('model_id', modelIds))
+      if (error) throw error
+  
+      // Delete product_models
+      ;({ error } = await db
+        .from('product_models')
+        .delete()
+        .in('model_id', modelIds))
+      if (error) throw error
+  
+      return { success: true }
+    } catch (error) {
+      console.error('Error deleting product models:', error)
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'An unknown error occurred'
+      }
+    }
+  }

--- a/actions/stats.ts
+++ b/actions/stats.ts
@@ -1,0 +1,244 @@
+// Buffett May. 26
+import { createClient } from '@supabase/supabase-js'
+import { Database } from '@/database.types'
+
+const db = createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+)
+
+type DailyStats = {
+    date: string
+    amount: number
+    quantity: number
+}
+
+type OrderWithItems = {
+    created_at: string | null
+    total_paid: number | null
+    order_items: {
+        quantity: number | null
+  }[]
+}
+
+type Output = {
+    success: boolean
+    data?: {
+        timeSeries: DailyStats[]
+    }
+    error?: string
+}
+
+type ProductStatsPoint = {
+  date: string
+  amount: number
+  quantity: number
+}
+
+type ProductStats = {
+  product_id: number
+  data: ProductStatsPoint[]
+}
+
+// 賣場整體表現
+// 根據選取的時間範圍，回傳所有商品加總 orders.total_paid （銷售額）、加總 order_items.quantity （銷售量）的時間序列
+// Input: 起始日期, 結束日期
+// Output: 每日銷售額, 每日銷售數量
+// {
+//   "success": true,
+//   "data": [
+//     {
+//       "date": "2024-01-02",
+//       "amount": 3800,
+//       "quantity": 21
+//     },
+//     ...
+//   ]
+// }
+// SQL:
+// SELECT 
+//   orders.created_at,
+//   orders.total_paid,
+//   order_items.quantity
+// FROM orders
+// LEFT JOIN order_items ON orders.order_id = order_items.order_id 
+// WHERE orders.created_at >= '2025-01-01'
+// AND orders.created_at <= '2025-06-01';
+export async function getProductSalesStats(
+  startDate: string, 
+  endDate: string
+): Promise<Output> {
+  console.log("getProductSalesStats", startDate, endDate)
+  try {
+    const { data: stats, error } = await db
+      .from('orders')
+      .select(`
+        created_at,
+        total_paid,
+        order_items (
+          quantity
+        )
+      `)
+      .gte('created_at', startDate)
+      .lte('created_at', endDate)
+
+    if (error) throw error
+
+    const dailyStatsMap = (stats || []).reduce((acc: Record<string, DailyStats>, order: OrderWithItems) => {
+      if (!order.created_at) return acc
+      
+      const date = new Date(order.created_at).toISOString().split('T')[0]
+      if (!acc[date]) {
+        acc[date] = {
+          date,
+          amount: 0,
+          quantity: 0
+        }
+      }
+      acc[date].amount += Number(order.total_paid) || 0
+      acc[date].quantity += (order.order_items || []).reduce((sum: number, item) => sum + (Number(item.quantity) || 0), 0)
+      return acc
+    }, {})
+
+    // Create date list between startDate and endDate
+    const dateList: string[] = []
+    const current = new Date(startDate)
+    const end = new Date(endDate)
+
+    while (current <= end) {
+      const dateStr = current.toISOString().split('T')[0]
+      dateList.push(dateStr)
+      current.setDate(current.getDate() + 1)
+    }
+
+    // Missing Data Date --> {date: "2025-01-01", amount: 0, quantity: 0}
+    const completeStats: DailyStats[] = dateList.map(date => {
+      return dailyStatsMap[date] ?? {
+        date,
+        amount: 0,
+        quantity: 0
+      }
+    })
+
+    return {
+      success: true,
+      data: {
+        timeSeries: completeStats.sort((a, b) => a.date.localeCompare(b.date)),
+      }
+    }
+
+  } catch (error) {
+    console.error('Error getting product sales stats:', error)
+    return {
+      success: false,
+      error: (error as Error).message
+    }
+  }
+}
+
+
+// 當使用者選取商品後，根據選取的時間範圍，回傳所選商品加總 order_items.amount（銷售額）、加總 order_items.quantity （銷售量）的時間序列
+// Input: Product_ID(s), 起始日期, 結束日期
+// Output: Product_IDs: {每日銷售額, 每日銷售數量}
+// {
+//   "success": true,
+//   "data": [
+//     {
+//       "product_id": 1,
+//       "data": [
+//         {
+//            "date": "2024-01-02",
+//            "amount": 3800,
+//            "quantity": 21
+//         },
+//         ...
+//       ]
+//     },
+//   ]
+// }
+export async function getProductStatsByIds(
+  productIds: number[],
+  startDate: string,
+  endDate: string
+): Promise<{ success: boolean; data?: ProductStats[]; error?: string }> {
+  try {
+    // Input validation
+    if (!productIds?.length) {
+      throw new Error('Product IDs are required')
+    }
+
+    const { data: orders, error } = await db
+      .from('orders')
+      .select(`
+        created_at,
+        order_items (
+          product_id,
+          quantity,
+          total_price
+        )
+      `)
+      .gte('created_at', startDate)
+      .lte('created_at', endDate)
+
+    if (error) throw error
+
+    // 建立日期清單
+    const dateList: string[] = []
+    const current = new Date(startDate)
+    const end = new Date(endDate)
+    while (current <= end) {
+      dateList.push(current.toISOString().split('T')[0])
+      current.setDate(current.getDate() + 1)
+    }
+
+    // 初始化 product map: product_id -> { date -> { amount, quantity } }
+    const productMap: Record<number, Record<string, ProductStatsPoint>> = {}
+
+    // Initialize data structure for each product ID and date
+    productIds.forEach(productId => {
+      productMap[productId] = {}
+      dateList.forEach(date => {
+        productMap[productId][date] = {
+          date,
+          amount: 0,
+          quantity: 0
+        }
+      })
+    })
+
+    // Process orders and aggregate data
+    if (orders) {
+      orders.forEach(order => {
+        if (!order.created_at || !order.order_items) return
+        
+        const date = new Date(order.created_at).toISOString().split('T')[0]
+        
+        order.order_items.forEach(item => {
+          if (!item.product_id || !productIds.includes(item.product_id)) return
+          
+          const productStats = productMap[item.product_id][date]
+          if (productStats) {
+            productStats.amount += Number(item.total_price) || 0
+            productStats.quantity += Number(item.quantity) || 0
+          }
+        })
+      })
+    }
+
+    // Convert to final format and sort data
+    const result: ProductStats[] = productIds.map(productId => ({
+      product_id: productId,
+      data: Object.values(productMap[productId]).sort((a, b) => 
+        a.date.localeCompare(b.date)
+      )
+    }))
+
+    return { success: true, data: result }
+  } catch (error) {
+    console.error('Error in getProductStatsByIds:', error)
+    return {
+      success: false,
+      error: (error as Error).message,
+    }
+  }
+}


### PR DESCRIPTION
## 📝 Pull Request: Delete Product Models and Related Data API

### ✅ What
- 新增 `deleteProductModels` 函式，能根據傳入的 `modelIds` 刪除指定的產品款式。
- 同時會依序刪除相關的子表資料：
  - `purchase_items`
  - `order_items`
  - `stock_records`
  - 最後刪除 `product_models`
- 確保不會因外鍵約束導致刪除失敗。

---

### 🧠 Why
- 原本直接刪除 `product_models` 會因為外鍵約束失敗。
- 需要手動依序刪除子表資料，確保資料一致性與完整性。
- 提供後端穩定的刪除功能，方便前端進行產品款式管理。

---

### ⚙️ How
- 使用 Supabase JS SDK 依序刪除四個資料表中的相關紀錄。
- 每一步都有錯誤檢查，一旦出錯即終止並回報。
- 使用 `try/catch` 包裝，回傳成功或錯誤訊息。

---

### 🧪 Test
- 已於本地端使用 mock 資料測試，刪除時順序正確。
- 測試成功避免了外鍵約束錯誤。
- 確認相關子資料一併刪除，資料庫狀態正常。

---

### ℹ️ Notes
- Supabase SDK 不支援多表 transaction，故採逐步刪除。
- 若未來資料庫設計改為 `ON DELETE CASCADE`，可簡化刪除邏輯。

<img width="1908" alt="截圖 2025-05-27 22 56 40" src="https://github.com/user-attachments/assets/285ad781-fd67-400e-887f-4028c3269c70" />
<img width="1326" alt="截圖 2025-05-27 22 55 28" src="https://github.com/user-attachments/assets/35497307-12c4-4c57-9f79-fb7ae935bf9c" />
<img width="1908" alt="截圖 2025-05-27 22 57 03" src="https://github.com/user-attachments/assets/540cd7ac-6b2c-4221-b0e3-a64c713df827" />