### PR TITLE
feat: implement inventory dashboard backend logic

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,6 +26,17 @@ export type StockRecordWithModel = StockRecord & ProductModel & Product & {
   is_ordered?: boolean;
 };
 
+export type InventoryDashboardRow = {
+  model_id: number;
+  model_name: string;
+  product_name: string;
+  stock_quantity: number;
+  last_updated: string;
+  supplier_name: string;
+  remaining_days: number;
+  is_ordered: boolean;
+};
+
 // 用於我的叫貨
 export type MyInventory = Supplier & Product & ProductModel & PurchaseItem & PurchaseBatch;
 

--- a/supabase/migrations/20250529091015_create_inventory_dashboard_view.sql
+++ b/supabase/migrations/20250529091015_create_inventory_dashboard_view.sql
@@ -1,0 +1,32 @@
+create or replace view inventory_dashboard as
+select
+  sr.model_id,
+  sr.stock_quantity,
+  sr.last_updated,
+  pm.model_name,
+  p.product_name,
+  s.supplier_name,
+
+  -- Total sales in the past 30 days
+  coalesce(sum(
+    case
+      when o.created_at >= now() - interval '30 day'
+      then oi.quantity
+      else 0
+    end
+  ), 0) as sales_30d,
+
+  -- Purchased in the past 7 days
+  bool_or(pb.created_at >= now() - interval '7 day') as has_recent_purchase
+
+from stock_records sr
+left join product_models pm on sr.model_id = pm.model_id
+left join products p on pm.product_id = p.product_id
+left join order_items oi on oi.model_id = pm.model_id
+left join orders o on oi.order_id = o.order_id
+left join purchase_items pi on pi.model_id = pm.model_id
+left join purchase_batches pb on pi.batch_id = pb.batch_id
+left join suppliers s on pb.supplier_id = s.supplier_id
+
+group by sr.model_id, sr.stock_quantity, sr.last_updated,
+         pm.model_name, p.product_name, s.supplier_name;


### PR DESCRIPTION
## Summary

1. Adds supabase migration for inventory dashboard view
2. Defines `InventoryDashboardRow` in `types.ts`.
3. Implements `getInventoryDashboardData()` to fetch view data and compute derived fields.

## Notes

- The frontend can replace `StockRecordWithModel` type with `InventoryDashboardRow` type.