### PR TITLE
fix: add fk for purchase_items

### DIFF
--- a/supabase/migrations/20250530063446_add_fk_for_purchase_items.sql
+++ b/supabase/migrations/20250530063446_add_fk_for_purchase_items.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "purchase_items" 
+ADD FOREIGN KEY ("model_id") REFERENCES "product_models" ("model_id")


### PR DESCRIPTION
Current DB schema was missing the foreign key relationship between `purchase_items` and `product_models`.
Add migration to fix it.