### PR TITLE
feat: connect purchase import dialog to backend

### DIFF
--- a/actions/products.ts
+++ b/actions/products.ts
@@ -15,3 +15,35 @@ export async function getProducts() {
 
   return data;
 }
+
+export async function getProductAndModelIdByNames(
+  productName: string,
+  modelName: string
+): Promise<{ product_id: number; model_id: number } | null> {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+
+  // get product_id
+  const { data: product, error: productError } = await supabase
+    .from("products")
+    .select("product_id")
+    .eq("product_name", productName)
+    .single();
+
+  if (productError || !product) return null;
+
+  // get model_id
+  const { data: model, error: modelError } = await supabase
+    .from("product_models")
+    .select("model_id")
+    .eq("model_name", modelName)
+    .eq("product_id", product.product_id)
+    .single();
+
+  if (modelError || !model) return null;
+
+  return {
+    product_id: product.product_id,
+    model_id: model.model_id,
+  };
+}

--- a/actions/purchase.ts
+++ b/actions/purchase.ts
@@ -11,7 +11,7 @@ export async function createPurchaseBatch(
   items?: {
     model_id: number;
     quantity: number;
-    unit_cost: number;
+    note?: string | null;
   }[]
 ) {
   const cookieStore = cookies();
@@ -36,7 +36,7 @@ export async function createPurchaseBatch(
         batch_id: data.batch_id,
         model_id: item.model_id,
         quantity: item.quantity,
-        unit_cost: item.unit_cost,
+        note: item.note ?? null,
       }))
     );
   }
@@ -48,7 +48,7 @@ export async function addPurchaseItem(
   batchId: number,
   modelId: number,
   quantity: number,
-  unitCost: number
+  note?: string | null
 ) {
   const cookieStore = cookies();
   const supabase = createClient(cookieStore);
@@ -59,8 +59,8 @@ export async function addPurchaseItem(
       {
         batch_id: batchId,
         model_id: modelId,
-        quantity,
-        unit_cost: unitCost,
+        quantity: quantity,
+        note: note ?? null,
       },
     ])
     .select()

--- a/app/(pages)/layout.tsx
+++ b/app/(pages)/layout.tsx
@@ -6,6 +6,7 @@ import { LoginForm } from "@/components/login-form";
 import { SiteHeader } from "@/components/site-header";
 import { SidebarInset } from "@/components/ui/sidebar";
 import { useSession } from "next-auth/react";
+import { Toaster } from "sonner";
 
 export default function PagesLayout({
   children,
@@ -41,6 +42,7 @@ export default function PagesLayout({
         <SiteHeader />
         <div className="flex flex-col items-center justify-center h-full w-full">
           {children}
+          <Toaster />
         </div>
       </SidebarInset>
     </SidebarProvider>


### PR DESCRIPTION
## Summary

1. Add `getProductAndModelIdByNames` lookup action.
2. Connect purchase import dialog to backend.
3. Update `createPurchaseBatch` for some parameters and error logging.
4. Enable toast notifications

## Notes

1. Current creation only supports products and models that are already in the database. Can consider to create new products and models if they do not exist.
2. The logic of `note` when purchasing has some differences between FE & BE. In some cases, the purchase dashboard may display duplicated notes.
